### PR TITLE
Support for Docker setup 🐋 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ wp-content/plugins/advanced-custom-fields-pro
 wp-content/ai1wm-backups/
 wp-content/plugins/all-in-one-wp-migration/storage/
 
+### Docker ###
+wp-content/themes/*/docker/volumes
+
 ### Linux ###
 *~
 

--- a/wp-content/themes/hozokit/.dockerignore
+++ b/wp-content/themes/hozokit/.dockerignore
@@ -1,0 +1,40 @@
+# Application Files
+node_modules
+.nvmrc
+.git
+.github
+.gitignore
+.gitattributes
+.nojekyll
+LICENSE
+README.md
+
+# Docker
+docker
+docker-compose.yml
+.dockerignore
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/wp-content/themes/hozokit/.env.example
+++ b/wp-content/themes/hozokit/.env.example
@@ -1,6 +1,7 @@
 APP_ENVIRONMENT='development'
 
 # Add your development URL here to make use of hot reloading.
+# Use your local ip when using the Docker setup e.g '192.168.0.15:8080'
 # APP_URL='http://localhost:3000'
 
 # Additional environment variables of your choice here can go here.

--- a/wp-content/themes/hozokit/docker-compose.yml
+++ b/wp-content/themes/hozokit/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  wordpress:
+    image: wordpress:latest
+    container_name: hozokit-wordpress
+    environment:
+      WORDPRESS_DB_HOST: hozokit-mysql
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_TABLE_PREFIX: "wp_"
+      WORDPRESS_DEBUG: 1
+    ports:
+      - "8080:80"
+    depends_on:
+      - "database"
+    volumes:
+      # Allows changes made to project directory to be accessed by the container via a bind mount.
+      - ${PWD}:/var/www/html/wp-content/themes/hozokit
+  database:
+    image: mysql:latest
+    container_name: hozokit-mysql
+    # PHP mysqli connector does not support caching_sha2_password plugin so using mysql_native_password instead.
+    command: "--default-authentication-plugin=mysql_native_password"
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+    # This allows for the database to be consulted via a software such as SQL Workbench or TablePlus
+    ports:
+      - 3307:3306
+    volumes:
+      - ./docker/volumes/mysql:/var/lib/mysql
+    # Used to compile styles and scripts.
+  node:
+    # Building a custom image described in a docker file.
+    build:
+      # Setting a context and dockerfile paths allows for Dockerfiles to be stored away in a sub-directory.
+      context: . # Context of build, this is where the project files are stored.
+      dockerfile: ./docker/node.dockerfile # The path to Dockerfile and name of the dockerfile to be built
+    # Setting an image name avoids the same image being built multiple times.
+    image: csalmeida/hozokit-node-tooling:latest
+    # Specified the name of the container, commented out to avoid name conflicts when running multiple instances of the image.
+    # container_name: protonmail_themes
+    ports:
+      - 2077:2077
+    depends_on:
+      - "wordpress"
+    restart: always
+    volumes:
+      # Allows changes made to project directory to be accessed by the container via a bind mount.
+      - ${PWD}:/var/www/html/wp-content/themes/hozokit
+      # Adds a volume to store node dependencies.
+      - /var/www/html/wp-content/themes/hozokit/node_modules

--- a/wp-content/themes/hozokit/docker/node.dockerfile
+++ b/wp-content/themes/hozokit/docker/node.dockerfile
@@ -1,0 +1,26 @@
+# This image makes use of a Node image running on Linux Alpine (latest versions of both)
+# Using digest SHA256 increases security
+FROM node:lts-alpine@sha256:8d5d490d1e18c9069b34b4a57df1cb3b8cd1b756f2f63f7b8240f39d7c01c402
+
+# Adds a package to act as PID 1 so that Node doesn't take that place.
+# Node wasn't built to run as PID 1 and avoiding it prevents unexpected behaviour.
+RUN apk add dumb-init
+
+# A work directory is required to be used by npm install
+WORKDIR /var/www/html/wp-content/themes/hozokit
+
+# Copy all project files to the container
+# Files in the location of this file are copied to WORKDIR in the container
+# Scopes permissions to user node instead of root.
+COPY --chown=node:node ["scripts", "styles", "assets", "style.css", "gulpfile.js", "package*.json", "./"]
+
+# Install dependencies
+RUN npm ci
+
+EXPOSE 2077
+
+# Switches user from root to node.
+USER node
+
+# The process this container should run
+CMD ["dumb-init", "npm", "start"]


### PR DESCRIPTION
- Adds support to spin up a development environment do develop a Hozokit theme with Docker

This brings advantages such as:

- No need to configure or install WordPress, MySQL or Node, this is now all automated.
- `npm install` and `npm run watch` are ran automatically.

For anyone using Docker you can try it by changing directory into the theme folder and running `docker compose up`.
If environment variables are changed run `docker compose restart`.
To shutdown the containers run `docker compose down`.

At the moment the WordPress site can be accessed via `localhost:8080` or `localhost:2077` if hot reloading is setup. 
